### PR TITLE
KDVMB-268 Fix crash in number format

### DIFF
--- a/lib/i18n/sfNumberFormat.class.php
+++ b/lib/i18n/sfNumberFormat.class.php
@@ -138,7 +138,7 @@ class sfNumberFormat
     ini_set('precision', $precision);
 
     list($number, $decimal) = $this->formatDecimal($string);
-    $integer = $this->formatInteger($this->fixFloat(abs($number)));
+    $integer = $this->formatInteger($this->fixFloat(abs((float)$number)));
 
     $result = (strlen($decimal) > 0) ? $integer.$decimal : $integer;
 


### PR DESCRIPTION
abs expects int or float, not string.